### PR TITLE
Support for PHP functions as a filter

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -155,16 +155,17 @@ class GUMP
 			$filters = explode('|', $filters);
 
 			foreach($filters as $filter)
-			{	
-				$method = 'filter_'.$filter;
-				
-				if(method_exists('GUMP', $method))
+			{
+				//First try built in or extended filters
+				if(method_exists('GUMP', 'filter_'.$filter))
 				{
+					$method = 'filter_'.$filter;
 					$input[$field] = GUMP::$method($input[$field]);
 				}
-				else if(function_exists($method))
+				//Else try for a php function
+				else if(function_exists($filter))
 				{
-					$input[$field] = $method($input[$field]);
+					$input[$field] = $filter($input[$field]);
 				}
 				else
 				{
@@ -177,20 +178,7 @@ class GUMP
 	}
 	
 	// ** ------------------------- Filters --------------------------------------- ** //	
-	
-	/**
-	 * Trim the provided string
-	 * 
-	 * @static
-	 * @access protected
-	 * @param  string $value
-	 * @return string
-	 */
-	protected static function filter_trim($value)
-	{
-		return trim($value);
-	}
-	
+		
 	/**
 	 * Base64 encode the provided string
 	 * 
@@ -203,33 +191,7 @@ class GUMP
 	{
 		return base64_encode($value);
 	}
-	
-	/**
-	 * SHA1 encrypt the provided string
-	 * 
-	 * @static
-	 * @access protected
-	 * @param  string $value
-	 * @return string
-	 */
-	protected static function filter_sha1($value)
-	{
-		return sha1($value);
-	}
-	
-	/**
-	 * MD5 encode the provided string
-	 * 
-	 * @static
-	 * @access protected
-	 * @param  string $value
-	 * @return string
-	 */
-	protected static function filter_md5($value)
-	{
-		return md5($value);
-	}
-	
+		
 	/**
 	 * Sanitize the string by removing any script tags
 	 * 


### PR DESCRIPTION
Instead of defining filter_sha1 for example, the sha1() function is called directly. I find this much more flexible as you are not limited to those that are defined or extended.
