### PR TITLE
Fixed invalid cc number length

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -1244,11 +1244,11 @@ class GUMP
 		
 		if(function_exists('mb_strlen'))
 		{
-			$number_length = mb_strlen($input[$field]);
+			$number_length = mb_strlen($number);
 		}
 		else
 		{
-			$number_length = strlen($input[$field]);
+			$number_length = strlen($number);
 		}		
 	
 	  	$parity = $number_length % 2;


### PR DESCRIPTION
The credit card number may be stripped of non-digits via `$number = preg_replace('/\D/', '', $input[$field]);`, however the length of the card number is being determined by reading the string length of `$input[$field]` instead of `$number`. This leads to an undefined index error at line 1260.
