### PR TITLE
Fixed validating "required" on non-scalar values

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -702,7 +702,7 @@ class GUMP
 	 */
 	protected function validate_required($field, $input, $param = NULL)
 	{
-		if(isset($input[$field]) && trim($input[$field]) != '')
+		if(isset($input[$field]) && $this->trimScalar($input[$field]) != '')
 		{
 			return;
 		}
@@ -1492,6 +1492,20 @@ class GUMP
             'rule'  => __FUNCTION__,
             'param' => $param
         );
+    }
+    
+    /**
+     * Trims whitespace only when the value is a scalar
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    protected function trimScalar($value)
+    {
+        if (is_scalar($value)) {
+            $value = trim($value);
+        }
+        return $value;
     }
     
 } // EOC


### PR DESCRIPTION
Validating with the "required" rule fails when the field value is non-scalar, eg an object or array. The bug seems to be caused by passing the field value through trim() without first checking if the value may be cast to a string.

Recreating the error:

``` php
$gump = new GUMP();
$gump->validation_rules([
    "name"    => "required",
    "address" => "required"
]);

// The "address" field fails validation because the field value is an object.
$values = [
    "name"    => "headzoo",
    "address" => new stdClass()
];
$is_valid = $gump->run($values);
```
