### PR TITLE
Removed redundant code

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -342,7 +342,7 @@ class GUMP
 	                    {
 	                        $this->errors[] = array(
 	                            'field' => $field,
-	                            'value' => isset($input[$field]) ? $input[$field] : NULL,
+	                            'value' => $input[$field],
 	                            'rule'  => $method,
 	                            'param' => $param
 	                        );


### PR DESCRIPTION
I had used `'value' = isset($input[$field]) ? $input[$field] : NULL` before wrapping the whole block of code in `if (isset($input[$field]))`. Forgot to remove the first isset.
