### PR TITLE
sanitize 2nd parameter can be a whitelist fields

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -239,7 +239,9 @@ class GUMP
 		{
 			$fields = array_keys($input);
 		}
-
+		
+		$return = array();
+		
 		foreach($fields as $field)
 		{
 			if(!isset($input[$field]))
@@ -274,11 +276,11 @@ class GUMP
 					$value = filter_var($value, FILTER_SANITIZE_STRING);
 				}
 
-				$input[$field] = $value;
+				$return[$field] = $value;
 			}
 		}
 
-		return $input;
+		return $return;
 	}
 
 	/**


### PR DESCRIPTION
The method now returns a new array with only the elements allowed by $fields param.
Useful for ORM or active record: the sanitized array must contain only keys that match table columns.

With this edit you can "whitelist" the submitted data passing an array of allowed keys/columns as 2nd parameter sanitize() method. All the array keys not included will be ignored and will be not in the sanitized array.

Before I explained here in an issue: 
https://github.com/Wixel/GUMP/issues/48
