### PR TITLE
Added new method get_errors_array() to return the errors as key value pa...

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -505,6 +505,120 @@ class GUMP
 			return $buffer;
 		}
 	}
+	
+	/**
+	 * Process the validation errors and return an array of errors with field names as keys
+	 *
+	 * @return array
+	 * @return null (if empty);
+	 */
+	public function get_errors_array()
+	{
+		if(empty($this->errors)) {
+			return ($convert_to_string)? null : array();
+		}
+
+		$resp = array();
+
+		foreach($this->errors as $e) {
+
+			$field = ucwords(str_replace(array('_','-'), chr(32), $e['field']));
+			$param = $e['param'];
+			
+			// Let's fetch explicit field names if they exist
+			if(array_key_exists($e['field'], self::$fields)) {
+				$field = self::$fields[$e['field']];
+			}
+
+			switch($e['rule']) {
+				case 'mismatch' :
+					$resp[$field] = "There is no validation rule for $field";
+					break;
+				case 'validate_required':
+					$resp[$field] = "The $field field is required";
+					break;
+				case 'validate_valid_email':
+					$resp[$field] = "The $field field is required to be a valid email address";
+					break;
+				case 'validate_max_len':
+					if($param == 1) {
+						$resp[$field] = "The $field field needs to be shorter than $param character";
+					} else {
+						$resp[$field] = "The $field field needs to be shorter than $param characters";
+					}
+					break;
+				case 'validate_min_len':
+					if($param == 1) {
+						$resp[$field] = "The $field field needs to be longer than $param character";
+					} else {
+						$resp[$field] = "The $field field needs to be longer than $param characters";
+					}
+					break;
+				case 'validate_exact_len':
+					if($param == 1) {
+						$resp[$field] = "The $field field needs to be exactly $param character in length";
+					} else {
+						$resp[$field] = "The $field field needs to be exactly $param characters in length";
+					}
+					break;
+				case 'validate_alpha':
+					$resp[$field] = "The $field field may only contain alpha characters(a-z)";
+					break;
+				case 'validate_alpha_numeric':
+					$resp[$field] = "The $field field may only contain alpha-numeric characters";
+					break;
+				case 'validate_alpha_dash':
+					$resp[$field] = "The $field field may only contain alpha characters &amp; dashes";
+					break;
+				case 'validate_numeric':
+					$resp[$field] = "The $field field may only contain numeric characters";
+					break;
+				case 'validate_integer':
+					$resp[$field] = "The $field field may only contain a numeric value";
+					break;
+				case 'validate_boolean':
+					$resp[$field] = "The $field field may only contain a true or false value";
+					break;
+				case 'validate_float':
+					$resp[$field] = "The $field field may only contain a float value";
+					break;
+				case 'validate_valid_url':
+					$resp[$field] = "The $field field is required to be a valid URL";
+					break;
+				case 'validate_url_exists':
+					$resp[$field] = "The $field URL does not exist";
+					break;
+				case 'validate_valid_ip':
+					$resp[$field] = "The $field field needs to contain a valid IP address";
+					break;
+				case 'validate_valid_cc':
+					$resp[$field] = "The $field field needs to contain a valid credit card number";
+					break;
+				case 'validate_valid_name':
+					$resp[$field] = "The $field field needs to contain a valid human name";
+					break;
+				case 'validate_contains':
+					$resp[$field] = "The $field field needs to contain one of these values: ".implode(', ', $param);
+					break;
+				case 'validate_street_address':
+					$resp[$field] = "The $field field needs to be a valid street address";
+					break;
+				case 'validate_date':
+					$resp[$field] = "The $field field needs to be a valid date";
+					break;
+				case 'validate_min_numeric':
+					$resp[$field] = "The $field field needs to be a numeric value, equal to, or higher than $param";
+					break;
+				case 'validate_max_numeric':
+					$resp[$field] = "The $field field needs to be a numeric value, equal to, or lower than $param";
+					break;
+				default:
+					$resp[$field] = "The $field field is invalid";				
+			}
+		}
+
+		return $resp;
+	}
 
 	/**
 	 * Filter the input data according to the specified filter set


### PR DESCRIPTION
...irs.

By calling get_errors_array() it returns an array which could be access as follows:

$errors = $gump->get_errors_array();
echo $errors['username'];
echo $errors['password'];

Obviously this limits the errors per field to one single error at a time.
