### PR TITLE
new validators, containsList, DoesNotContainList, startsWith

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -194,11 +194,14 @@ Available Validators
 * valid_cc `Check for a valid credit card number (Uses the MOD10 Checksum Algorithm)`
 * valid_name `Check for a valid format human name`
 * contains,n `Verify that a value is contained within the pre-defined value set`
+* containsList,n `Verify that a value is contained within the pre-defined value set. Comma separated, list not outputted.`
+* doesNotcontainList,n `Verify that a value is not contained within the pre-defined value set. Comma separated, list not outputted.`
 * street_address `Checks that the provided string is a likely street address. 1 number, 1 or more space, 1 or more letters`
 * iban `Check for a valid IBAN`
 * min_numeric `Determine if the provided numeric value is higher or equal to a specific value`
 * max_numeric `Determine if the provided numeric value is lower or equal to a specific value`
 * date `Determine if the provided input is a valid date (ISO 8601)`
+* starts `Ensures the value starts with a certain character / set of character`
 
 Available Filters
 -----------------

--- a/gump.class.php
+++ b/gump.class.php
@@ -487,9 +487,6 @@ class GUMP
 				case 'validate_street_address':
 					$resp[] = "The <span class=\"$field_class\">$field</span> field needs to be a valid street address";
 					break;
-				case 'validate_startsWith':
-					$resp[] = "The <span class=\"$field_class\">$field</span> field needs to begin with $param";
-					break;
 				case 'validate_date':
 					$resp[] = "The <span class=\"$field_class\">$field</span> field needs to be a valid date";
 					break;
@@ -499,8 +496,8 @@ class GUMP
 				case 'validate_max_numeric':
 					$resp[] = "The <span class=\"$field_class\">$field</span> field needs to be a numeric value, equal to, or lower than $param";
 					break;
-				case 'validate_starts' :
-					$resp[] = "The <span class=\"$field_class\">$field</span> field is required to start with ".$param;
+				case 'validate_starts':
+					$resp[] = "The <span class=\"$field_class\">$field</span> field needs to start with $param";
 					break;
 				default:
 					$resp[] = "The <span class=\"$field_class\">$field</span> field is invalid";				
@@ -892,34 +889,7 @@ class GUMP
 
 	// ** ------------------------- Validators ------------------------------------ ** //
 
-	/**
-	 * Verify that a value's first character equals a pre-defined value
-	 * 
-	 * Usage: '<index>' => 'startsWith,a'
-	 *	
-	 * @access protected
-	 * @param  string $field
-	 * @param  array $input
-	 * @return mixed
-	 */
-	protected function validate_startsWith($field, $input, $param = NULL)
-	{
-		$param = trim(strtolower($param));
-		$value = trim(strtolower($input[$field]));
 		
-		if( substr($value, 0, 1) === $param ) { // valid, return nothing
-			return;
-		} else {
-			return array(
-				'field' => $field,
-				'value' => $value,
-				'rule'	=> __FUNCTION__,
-				'param' => $param
-			);			
-		}
-	}
-	
-	
 	/**
 	 * Verify that a value is contained within the pre-defined value set
 	 *


### PR DESCRIPTION
- replaced array check with class variable array check instead. (You were replacing underscore and hyphen characters in field names with spaces, this needed to be an application option instead.)
- added in new validator, containsList, with comma separated values. Does not output values (as list can be large)
- added in new validator, doesNotcontainList, with comma separated values. Does not output values (as list can be large)
- added in new validator, startsWith. Has better function name than recently accepted ‘starts’, and also follows application form better. Though mine lowercase checks, not exact check.
