### PR TITLE
Fix for passing arrays as values

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -260,7 +260,9 @@ class GUMP
 			else
 			{
 				$value = $input[$field];
-
+				if (is_array($value)){
+					$value = null;
+				}
 				if(is_string($value))
 				{
 					if($magic_quotes === TRUE)
@@ -324,8 +326,8 @@ class GUMP
 
 			$rules = explode('|', $rules);
 			
-	        if(in_array("required", $rules) || (isset($input[$field]) && trim($input[$field]) != ''))
-	        {			
+			if(in_array("required", $rules) || (isset($input[$field]) && !is_array($input[$field]) && trim($input[$field]) != ''))
+			{
 				foreach($rules as $rule)
 				{
 					$method = NULL;


### PR DESCRIPTION
As of now if you pass an array as a value, trim will throw a warning.
I also tweaked the sanitize method to return null in case of an array being passed as a value to prevent further issues.