### PR TITLE
Revert "Update gump.class.php"

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -357,11 +357,14 @@ class GUMP
 						if (isset($input[$field])) {
 							$result = call_user_func(self::$validation_methods[$rule], $field, $input, $param);
 
-							$result = $this->$method($field, $input, $param);
-	
-							if(is_array($result)) // Validation Failed
+							if (!$result) // Validation Failed
 							{
-								$this->errors[] = $result;
+								$this->errors[] = array(
+									'field' => $field,
+									'value' => $input[$field],
+									'rule'  => $method,
+									'param' => $param
+								);
 							}
 						}
 					}


### PR DESCRIPTION
This reverts commit 8d2ae7b4539d0ed48383bb80f87d80098fecc24e.

Issue #58 suggested custom validators were being invoked and storing error results improperly. Custom validators are stored in a static class array and return boolean. The changes made in this commit break the custom validator functionality.

This commit will resolve Issue #66.