### PR TITLE
Made improvements to the documentation for the regex validator.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -205,7 +205,7 @@ Available Validators
 * date `Determine if the provided input is a valid date (ISO 8601)`
 * starts `Ensures the value starts with a certain character / set of character`
 * phone_number `Validate phone numbers that match the following examples: 555-555-5555 , 5555425555, 555 555 5555, 1(519) 555-4444, 1 (519) 555-4422, 1-555-555-5555`
-* regex `You can pass a custom regex using the following format: 'regex&&&/your-regex/`
+* regex `You can pass a custom regex using the following format: 'regex,/your-regex/'`
 * valid_json_string `validate string to check if it's a valid json format`
 
 Available Filters

--- a/gump.class.php
+++ b/gump.class.php
@@ -2040,7 +2040,7 @@ class GUMP
     /**
      * Custom regex validator.
      *
-     * Usage: '<index>' => 'regex&&&/regex/'
+     * Usage: '<index>' => 'regex,/your-regex-expression/'
      *
      * @param string $field
      * @param array  $input


### PR DESCRIPTION
The documentation used to state that the proper use of the regex validator is `regex&&&/your-regex/`. However, the proper delimiter is `,`, not `&&&`. This caused a small amount of confusion for my team, and this fix in the documentation might save other developers in the future.