### PR TITLE
Added get_instance to avoid multiple instances of GUMP

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -12,6 +12,9 @@
  */
 class GUMP
 {
+    //Singleton instance of GUMP
+    protected static $instance = null;
+
     // Validation rules for execution
     protected $validation_rules = array();
 
@@ -29,6 +32,23 @@ class GUMP
 
     // Customer filter methods
     protected static $filter_methods = array();
+
+    // ** ------------------------- Instance Helper ---------------------------- ** //
+    /**
+     * Function to create and return previously created instance
+     *
+     * @return GUMP
+     */
+
+    public static function get_instance(){
+        if(self::$instance === null)
+        {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+
 
     // ** ------------------------- Validation Data ------------------------------- ** //
 
@@ -58,7 +78,7 @@ class GUMP
      */
     public static function is_valid(array $data, array $validators)
     {
-        $gump = new self();
+        $gump = self::get_instance();
 
         $gump->validation_rules($validators);
 
@@ -79,7 +99,7 @@ class GUMP
      */
     public static function filter_input(array $data, array $filters)
     {
-        $gump = new self();
+        $gump = self::get_instance();
 
         return $gump->filter($data, $filters);
     }


### PR DESCRIPTION
**This is a fix for two issues in GUMP**
1: When you use is_valid() and filter_input(), $gump = new self() creates multiple unwanted instances of GUMP.
2: If you extend GUMP class and if the extended class has a constructor defined, issue mentioned in point 1 tends to call constructor multiple times hence messing up the code logic.

Fix contains **singleton pattern** implementation for GUMP.
This way, instance is created once and passed around multiple times also resulting into performance improvement and less resource usage.

Have tested the changes against all files in example directory and also currently using it in one of my live projects.