### PR TITLE
Makes the keys of the array identical for get_errors_array

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -606,89 +606,90 @@ class GUMP
         $resp = array();
 
         foreach ($this->errors as $e) {
-            $field = ucwords(str_replace(array('_', '-'), chr(32), $e['field']));
+            $field = $e['field'];
+            $field_human = ucwords(str_replace(array('_', '-'), chr(32), $field));
             $param = $e['param'];
 
             // Let's fetch explicit field names if they exist
-            if (array_key_exists($e['field'], self::$fields)) {
-                $field = self::$fields[$e['field']];
+            if (array_key_exists($field, self::$fields)) {
+                $field = self::$fields[$field];
             }
 
             switch ($e['rule']) {
                 case 'mismatch' :
-                    $resp[$field] = "There is no validation rule for $field";
+                    $resp[$field] = "There is no validation rule for $field_human";
                     break;
                 case 'validate_required':
-                    $resp[$field] = "The $field field is required";
+                    $resp[$field] = "The $field_human field is required";
                     break;
                 case 'validate_valid_email':
-                    $resp[$field] = "The $field field is required to be a valid email address";
+                    $resp[$field] = "The $field_human field is required to be a valid email address";
                     break;
                 case 'validate_max_len':
-                    $resp[$field] = "The $field field needs to be $param or shorter in length";
+                    $resp[$field] = "The $field_human field needs to be $param or shorter in length";
                     break;
                 case 'validate_min_len':
-                    $resp[$field] = "The $field field needs to be $param or longer in length";
+                    $resp[$field] = "The $field_human field needs to be $param or longer in length";
                     break;
                 case 'validate_exact_len':
-                    $resp[$field] = "The $field field needs to be exactly $param characters in length";
+                    $resp[$field] = "The $field_human field needs to be exactly $param characters in length";
                     break;
                 case 'validate_alpha':
-                    $resp[$field] = "The $field field may only contain alpha characters(a-z)";
+                    $resp[$field] = "The $field_human field may only contain alpha characters(a-z)";
                     break;
                 case 'validate_alpha_numeric':
-                    $resp[$field] = "The $field field may only contain alpha-numeric characters";
+                    $resp[$field] = "The $field_human field may only contain alpha-numeric characters";
                     break;
                 case 'validate_alpha_dash':
-                    $resp[$field] = "The $field field may only contain alpha characters &amp; dashes";
+                    $resp[$field] = "The $field_human field may only contain alpha characters &amp; dashes";
                     break;
                 case 'validate_numeric':
-                    $resp[$field] = "The $field field may only contain numeric characters";
+                    $resp[$field] = "The $field_human field may only contain numeric characters";
                     break;
                 case 'validate_integer':
-                    $resp[$field] = "The $field field may only contain a numeric value";
+                    $resp[$field] = "The $field_human field may only contain a numeric value";
                     break;
                 case 'validate_boolean':
-                    $resp[$field] = "The $field field may only contain a true or false value";
+                    $resp[$field] = "The $field_human field may only contain a true or false value";
                     break;
                 case 'validate_float':
-                    $resp[$field] = "The $field field may only contain a float value";
+                    $resp[$field] = "The $field_human field may only contain a float value";
                     break;
                 case 'validate_valid_url':
-                    $resp[$field] = "The $field field is required to be a valid URL";
+                    $resp[$field] = "The $field_human field is required to be a valid URL";
                     break;
                 case 'validate_url_exists':
-                    $resp[$field] = "The $field URL does not exist";
+                    $resp[$field] = "The $field_human URL does not exist";
                     break;
                 case 'validate_valid_ip':
-                    $resp[$field] = "The $field field needs to contain a valid IP address";
+                    $resp[$field] = "The $field_human field needs to contain a valid IP address";
                     break;
                 case 'validate_valid_cc':
-                    $resp[$field] = "The $field field needs to contain a valid credit card number";
+                    $resp[$field] = "The $field_human field needs to contain a valid credit card number";
                     break;
                 case 'validate_valid_name':
-                    $resp[$field] = "The $field field needs to contain a valid human name";
+                    $resp[$field] = "The $field_human field needs to contain a valid human name";
                     break;
                 case 'validate_contains':
-                    $resp[$field] = "The $field field needs to contain one of these values: ".implode(', ', $param);
+                    $resp[$field] = "The $field_human field needs to contain one of these values: ".implode(', ', $param);
                     break;
                 case 'validate_street_address':
-                    $resp[$field] = "The $field field needs to be a valid street address";
+                    $resp[$field] = "The $field_human field needs to be a valid street address";
                     break;
                 case 'validate_date':
-                    $resp[$field] = "The $field field needs to be a valid date";
+                    $resp[$field] = "The $field_human field needs to be a valid date";
                     break;
                 case 'validate_min_numeric':
-                    $resp[$field] = "The $field field needs to be a numeric value, equal to, or higher than $param";
+                    $resp[$field] = "The $field_human field needs to be a numeric value, equal to, or higher than $param";
                     break;
                 case 'validate_max_numeric':
-                    $resp[$field] = "The $field field needs to be a numeric value, equal to, or lower than $param";
+                    $resp[$field] = "The $field_human field needs to be a numeric value, equal to, or lower than $param";
                     break;
                 case 'validate_min_age':
-                    $resp[$field] = "The $field field needs to have an age greater than or equal to $param";
+                    $resp[$field] = "The $field_human field needs to have an age greater than or equal to $param";
                     break;
                 default:
-                    $resp[$field] = "The $field field is invalid";
+                    $resp[$field] = "The $field_human field is invalid";
             }
         }
 


### PR DESCRIPTION
This change keeps the key values of the array returned to be
identical to the ones that were given to the validator originally.
