### PR TITLE
#106 html tags white list

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -54,6 +54,10 @@ class GUMP
 
     public static $basic_tags = '<br><p><a><strong><b><i><em><img><blockquote><code><dd><dl><hr><h1><h2><h3><h4><h5><h6><label><ul><li><span><sub><sup>';
 
+    // By default the instance_tags are the basic tags, but they can be changed on a per instance
+    // of GUMP basis.
+    public $instance_tags = $basic_tags;
+
     public static $en_noise_words = "about,after,all,also,an,and,another,any,are,as,at,be,because,been,before,
 				  				  	 being,between,both,but,by,came,can,come,could,did,do,each,for,from,get,
 				  				  	 got,has,had,he,have,her,here,him,himself,his,how,if,in,into,is,it,its,it's,like,
@@ -927,7 +931,7 @@ class GUMP
      */
     protected function filter_basic_tags($value, $params = null)
     {
-        return strip_tags($value, self::$basic_tags);
+        return strip_tags($value, $this->instance_tags);
     }
 
     /**

--- a/gump.class.php
+++ b/gump.class.php
@@ -55,8 +55,8 @@ class GUMP
     public static $basic_tags = '<br><p><a><strong><b><i><em><img><blockquote><code><dd><dl><hr><h1><h2><h3><h4><h5><h6><label><ul><li><span><sub><sup>';
 
     // By default the instance_tags are the basic tags, but they can be changed on a per instance
-    // of GUMP basis.
-    public $instance_tags = $basic_tags;
+    // of GUMP basis (see the constructor)
+    public $instance_tags;
 
     public static $en_noise_words = "about,after,all,also,an,and,another,any,are,as,at,be,because,been,before,
 				  				  	 being,between,both,but,by,came,can,come,could,did,do,each,for,from,get,
@@ -69,6 +69,15 @@ class GUMP
 
     // field characters below will be replaced with a space.
     protected $fieldCharsToRemove = array('_', '-');
+
+    public function __construct($opts = array()) {
+      $this->instance_tags = static::$basic_tags;
+
+      // permit overrides
+      foreach($opts as $key => $value) {
+        $this->$key = $value;
+      }
+    }
 
     // ** ------------------------- Validation Helpers ---------------------------- ** //
 

--- a/gump.class.php
+++ b/gump.class.php
@@ -338,7 +338,9 @@ class GUMP
                         }
                     }
 
-                    $value = filter_var($value, FILTER_SANITIZE_STRING);
+                    // old code - filter_var($value, FILTER_SANITIZE_STRING);
+                    // See #106 https://github.com/Wixel/GUMP/issues/106
+                    $value = $this->filter_basic_tags($value);
                 }
 
                 $return[$field] = $value;


### PR DESCRIPTION
- Creates an instance tags for a per-instance filtering
- Adds a constructor for instance based-overrides
- Uses strip_tags in the basic string sanitization instead of the html-stripping filter_var
