### PR TITLE
add param $field_name_as_key in get_errors_array()

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -2049,7 +2049,7 @@ class GUMP
             return;
         }
 
-        $regex = '/^(\d[\s-]?)?[\(\[\s-]{0,2}?\d{3}[\)\]\s-]{0,2}?\d{3}[\s-]?\d{4}$/i';
+        $regex = '/^(\d{1,2}[\s-]?)?[\(\[\s-]{0,2}?\d{3}[\)\]\s-]{0,2}?\d{3}[\s-]?\d{4}$/i';
         if (!preg_match($regex, $input[$field])) {
             return array(
           'field' => $field,

--- a/gump.class.php
+++ b/gump.class.php
@@ -594,10 +594,11 @@ class GUMP
      * Process the validation errors and return an array of errors with field names as keys.
      *
      * @param $convert_to_string
+     * @param $field_name_as_key
      *
      * @return array | null (if empty)
      */
-    public function get_errors_array($convert_to_string = null)
+    public function get_errors_array($convert_to_string = null, $field_name_as_key = true)
     {
         if (empty($this->errors)) {
             return ($convert_to_string) ? null : array();
@@ -614,81 +615,83 @@ class GUMP
                 $field = self::$fields[$e['field']];
             }
 
+			$key = ($field_name_as_key) ? $field : $e['field'];
+
             switch ($e['rule']) {
                 case 'mismatch' :
-                    $resp[$field] = "There is no validation rule for $field";
+                    $resp[$key] = "There is no validation rule for $field";
                     break;
                 case 'validate_required':
-                    $resp[$field] = "The $field field is required";
+                    $resp[$key] = "The $field field is required";
                     break;
                 case 'validate_valid_email':
-                    $resp[$field] = "The $field field is required to be a valid email address";
+                    $resp[$key] = "The $field field is required to be a valid email address";
                     break;
                 case 'validate_max_len':
-                    $resp[$field] = "The $field field needs to be $param or shorter in length";
+                    $resp[$key] = "The $field field needs to be $param or shorter in length";
                     break;
                 case 'validate_min_len':
-                    $resp[$field] = "The $field field needs to be $param or longer in length";
+                    $resp[$key] = "The $field field needs to be $param or longer in length";
                     break;
                 case 'validate_exact_len':
-                    $resp[$field] = "The $field field needs to be exactly $param characters in length";
+                    $resp[$key] = "The $field field needs to be exactly $param characters in length";
                     break;
                 case 'validate_alpha':
-                    $resp[$field] = "The $field field may only contain alpha characters(a-z)";
+                    $resp[$key] = "The $field field may only contain alpha characters(a-z)";
                     break;
                 case 'validate_alpha_numeric':
-                    $resp[$field] = "The $field field may only contain alpha-numeric characters";
+                    $resp[$key] = "The $field field may only contain alpha-numeric characters";
                     break;
                 case 'validate_alpha_dash':
-                    $resp[$field] = "The $field field may only contain alpha characters &amp; dashes";
+                    $resp[$key] = "The $field field may only contain alpha characters &amp; dashes";
                     break;
                 case 'validate_numeric':
-                    $resp[$field] = "The $field field may only contain numeric characters";
+                    $resp[$key] = "The $field field may only contain numeric characters";
                     break;
                 case 'validate_integer':
-                    $resp[$field] = "The $field field may only contain a numeric value";
+                    $resp[$key] = "The $field field may only contain a numeric value";
                     break;
                 case 'validate_boolean':
-                    $resp[$field] = "The $field field may only contain a true or false value";
+                    $resp[$key] = "The $field field may only contain a true or false value";
                     break;
                 case 'validate_float':
-                    $resp[$field] = "The $field field may only contain a float value";
+                    $resp[$key] = "The $field field may only contain a float value";
                     break;
                 case 'validate_valid_url':
-                    $resp[$field] = "The $field field is required to be a valid URL";
+                    $resp[$key] = "The $field field is required to be a valid URL";
                     break;
                 case 'validate_url_exists':
-                    $resp[$field] = "The $field URL does not exist";
+                    $resp[$key] = "The $field URL does not exist";
                     break;
                 case 'validate_valid_ip':
-                    $resp[$field] = "The $field field needs to contain a valid IP address";
+                    $resp[$key] = "The $field field needs to contain a valid IP address";
                     break;
                 case 'validate_valid_cc':
-                    $resp[$field] = "The $field field needs to contain a valid credit card number";
+                    $resp[$key] = "The $field field needs to contain a valid credit card number";
                     break;
                 case 'validate_valid_name':
-                    $resp[$field] = "The $field field needs to contain a valid human name";
+                    $resp[$key] = "The $field field needs to contain a valid human name";
                     break;
                 case 'validate_contains':
-                    $resp[$field] = "The $field field needs to contain one of these values: ".implode(', ', $param);
+                    $resp[$key] = "The $field field needs to contain one of these values: ".implode(', ', $param);
                     break;
                 case 'validate_street_address':
-                    $resp[$field] = "The $field field needs to be a valid street address";
+                    $resp[$key] = "The $field field needs to be a valid street address";
                     break;
                 case 'validate_date':
-                    $resp[$field] = "The $field field needs to be a valid date";
+                    $resp[$key] = "The $field field needs to be a valid date";
                     break;
                 case 'validate_min_numeric':
-                    $resp[$field] = "The $field field needs to be a numeric value, equal to, or higher than $param";
+                    $resp[$key] = "The $field field needs to be a numeric value, equal to, or higher than $param";
                     break;
                 case 'validate_max_numeric':
-                    $resp[$field] = "The $field field needs to be a numeric value, equal to, or lower than $param";
+                    $resp[$key] = "The $field field needs to be a numeric value, equal to, or lower than $param";
                     break;
                 case 'validate_min_age':
-                    $resp[$field] = "The $field field needs to have an age greater than or equal to $param";
+                    $resp[$key] = "The $field field needs to have an age greater than or equal to $param";
                     break;
                 default:
-                    $resp[$field] = "The $field field is invalid";
+                    $resp[$key] = "The $field field is invalid";
             }
         }
 

--- a/gump.class.php
+++ b/gump.class.php
@@ -1318,6 +1318,33 @@ class GUMP
     }
 
     /**
+     * Determine if the provided value contains only alpha numeric characters with spaces, dashed and underscores.
+     *
+     * Usage: '<index>' => 'alpha_space_dash'
+     *
+     * @param string $field
+     * @param array  $input
+     * @param null   $param
+     *
+     * @return mixed
+     */
+    protected function validate_alpha_space_dash($field, $input, $param = null)
+    {
+        if (!isset($input[$field]) || empty($input[$field])) {
+            return;
+        }
+
+        if (!preg_match("/^([a-z0-9ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÒÓÔÕÖÙÚÛÜÝàáâãäåçèéêëìíîïðòóôõöùúûüýÿ\s_-])+$/i", $input[$field]) !== false) {
+            return array(
+                'field' => $field,
+                'value' => $input[$field],
+                'rule' => __FUNCTION__,
+                'param' => $param,
+            );
+        }
+    }
+
+    /**
      * Determine if the provided value is a valid number or numeric string.
      *
      * Usage: '<index>' => 'numeric'


### PR DESCRIPTION
With these changes, we can get an array of errors in a more convenient format for transfer to the frontend.

``` php
$gump->get_errors_array(null, false);
```

``` php
Array
(
    [name] => The Name field is required
    [surname] => The Surname field is required
    [email] => The E-mail field is required
    [phone] => The Phone field is required
    [subject] => The Choose subject field is required
)
```
