### PR TITLE
Update gump.class.php

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -306,7 +306,7 @@ class GUMP
             } else {
                 $value = $input[$field];
                 if (is_array($value)) {
-                    $value = null;
+                    $value = sanitize($value);
                 }
                 if (is_string($value)) {
                     if ($magic_quotes === true) {


### PR DESCRIPTION
Setting the $value to null when it is an array breaks the html input arrays (using the name="data[]" syntax). This can also be quite hard to debug because this behaviour is not expected by the user (at least in my case).