### PR TITLE
Compare fields: use another field as param

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -379,6 +379,10 @@ class GUMP
                     }
 
                     //self::$validation_methods[$rule] = $callback;
+                                        
+                    if (substr($param, 0, 1) == '_' && isset($input[substr($param, 1)])) {
+                        $param = $input[substr($param, 1)];
+                    }
 
                     if (is_callable(array($this, $method))) {
                         $result = $this->$method(


### PR DESCRIPTION
A very simple improvement to enable support for comparison between fields: simply uses "_" (underscore) as prefix of POST's key in param.

Example:
I'ld like validate that the field "first" is higher or equal to field "second". The rule for field "first" will be
min_numeric,_second