### PR TITLE
Added 0-9 to the validate_alpha_space regex to accept numbers.

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -1283,7 +1283,7 @@ class GUMP
             return;
         }
 
-        if (!preg_match("/^([a-zÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÒÓÔÕÖßÙÚÛÜÝàáâãäåçèéêëìíîïðòóôõöùúûüýÿ\s])+$/i", $input[$field]) !== false) {
+        if (!preg_match("/^([0-9a-zÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÒÓÔÕÖßÙÚÛÜÝàáâãäåçèéêëìíîïðòóôõöùúûüýÿ\s])+$/i", $input[$field]) !== false) {
             return array(
                 'field' => $field,
                 'value' => $input[$field],


### PR DESCRIPTION
I've added the proper regex to ensure that alphanumeric and spaces are correctly accepted. Previously numbers were being incorrectly invalidated.