### PR TITLE
Fixed : Credit Card Validation not working if all alphabets are enter…

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -1648,8 +1648,8 @@ class GUMP
 
 
         /**
-         * Bail out if $number_lenght is 0. 
-         * This can be the case if a user has entered only digits
+         * Bail out if $number_length is 0. 
+         * This can be the case if a user has entered only alphabets
          * 
          * @since 1.5
          */

--- a/gump.class.php
+++ b/gump.class.php
@@ -1646,6 +1646,23 @@ class GUMP
             $number_length = strlen($number);
         }
 
+
+        /**
+         * Bail out if $number_lenght is 0. 
+         * This can be the case if a user has entered only digits
+         * 
+         * @since 1.5
+         */
+        if( $number_length == 0 ) {
+            return array(
+                'field' => $field,
+                'value' => $input[$field],
+                'rule' => __FUNCTION__,
+                'param' => $param,
+            );
+        }
+
+
         $parity = $number_length % 2;
 
         $total = 0;


### PR DESCRIPTION
I had noticed that if a user enters only alphabets as a Credit Card number, then it does not validate & submits the data.

This was because we were stripping all alphabet from the input and later we were validating on **$total % 10 = 0**, whereas $total always is 0 if the number_length is 0. Hence it was validating it as a Valid Credit Card number.