### PR TITLE
Update the IDNA_VARAIANT to support PHP 7.3

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -1523,7 +1523,7 @@ class GUMP
         }
 
         if (function_exists('checkdnsrr')  && function_exists('idn_to_ascii')) {
-            if (checkdnsrr(idn_to_ascii($url), 'A') === false) {
+            if (checkdnsrr(idn_to_ascii($url, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46), 'A') === false) {
                 return array(
                     'field' => $field,
                     'value' => $input[$field],


### PR DESCRIPTION
The INTL_IDNA_VARIANT_2003 is now deprecated, therefore INTL_IDNA_VARIANT_UTS46 must be used.