### PR TITLE
Add has_validator and has_filter method

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -1950,4 +1950,15 @@ class GUMP
     {
         return !(!is_array($input[$field]) || count($input[$field]) != $params[0]);
     }
+
+    /**
+     * Checks if a validator method exists for a given rule.
+     *
+     * @param string $rule
+     * @return bool
+     */
+    public static function has_validator(string $rule): bool
+    {
+        return method_exists(__CLASS__, self::validator_to_method($rule)) || isset(self::$validation_methods[$rule]);
+    }
 }

--- a/gump.class.php
+++ b/gump.class.php
@@ -1961,4 +1961,16 @@ class GUMP
     {
         return method_exists(__CLASS__, self::validator_to_method($rule)) || isset(self::$validation_methods[$rule]);
     }
+
+    /**
+     * Checks if a filter method exists for a given filter.
+     * @param string $filter
+     * @return bool
+     */
+    public static function has_filter(string $filter): bool
+    {
+        return method_exists(__CLASS__, self::filter_to_method($filter))
+            || isset(self::$filter_methods[$filter])
+            || function_exists($filter);
+    }
 }

--- a/tests/StaticHasFilterTest.php
+++ b/tests/StaticHasFilterTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests;
+
+use GUMP;
+
+class StaticHasFilterTest extends BaseTestCase
+{
+    public function testHasFilterWhenExists(): void
+    {
+        $filterRules = [
+            // There are native filters
+            'noise_words',
+            'rmpunctuation',
+            'urlencode',
+            'htmlencode',
+            'sanitize_email',
+            'sanitize_numbers',
+            'sanitize_floats',
+            'sanitize_string',
+            'boolean',
+            'basic_tags',
+            'whole_number',
+            'ms_word_characters',
+            'lower_case',
+            'upper_case',
+            'slug',
+            // These are built-in functions
+            'trim',
+            'strtoupper',
+            'strtolower',
+            'intval',
+            'floatval',
+        ];
+
+        foreach ($filterRules as $filterRule) {
+            $this->assertTrue(GUMP::has_filter($filterRule));
+        }
+    }
+
+    public function testHasFilterWhenNotExists(): void
+    {
+        $this->assertFalse(GUMP::has_filter('custom_filter'));
+    }
+}

--- a/tests/StaticHasValidatorTest.php
+++ b/tests/StaticHasValidatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests;
+
+use GUMP;
+
+class StaticHasValidatorTest extends BaseTestCase
+{
+    public function testHasValidatorWhenExists(): void
+    {
+        $validationRules = [
+            'required',
+            'contains',
+            'contains_list',
+            'doesnt_contain_list',
+            'boolean',
+            'valid_email',
+            'max_len',
+            'min_len',
+            'exact_len',
+            'between_len',
+            'alpha',
+            'alpha_numeric',
+            'alpha_dash',
+            'alpha_numeric_dash',
+            'alpha_numeric_space',
+            'alpha_space',
+            'numeric',
+            'integer',
+            'float',
+            'valid_url',
+            'url_exists',
+            'valid_ip',
+            'valid_ipv4',
+            'valid_ipv6',
+            'valid_cc',
+            'valid_name',
+            'street_address',
+            'iban',
+            'date',
+            'min_age',
+            'max_numeric',
+            'min_numeric',
+            'starts',
+            'required_file',
+            'extension',
+            'equalsfield',
+            'guidv4',
+            'phone_number',
+            'regex',
+            'valid_json_string',
+            'valid_array_size_greater',
+            'valid_array_size_lesser',
+            'valid_array_size_equal',
+        ];
+
+        foreach ($validationRules as $rule) {
+            $this->assertTrue(GUMP::has_validator($rule));
+        }
+    }
+
+    public function testHasValidatorWhenNotExists(): void
+    {
+        $this->assertFalse(GUMP::has_validator('custom_rule'));
+    }
+}


### PR DESCRIPTION
This method checks if a validator method exists for a given rule.

The reason for adding this method is to prevent exceptions from being thrown when using the `add_validator` method with a rule that already exists. By using `has_validator`, we can ensure that a rule does not exist before adding it.

Here are the key changes:

1. **New Method:** The `has_validator` method takes a rule as a string parameter and returns a boolean value. It checks if a validator method exists for the given rule in the `Validator` class or if the rule is present in the `validation_methods` array.

2. **Test Cases:** Test cases for both happy and unhappy paths have been included to validate the functionality of the new has_validator method.
