### PR TITLE
Update gump.class.php to fix type of field error as integer

### DIFF
--- a/gump.class.php
+++ b/gump.class.php
@@ -1812,6 +1812,10 @@ class GUMP
      */
     protected function validate_extension($field, $input, array $params, $value = null)
     {
+        if (isset($input[$field]['error']) && gettype($input[$field]['error']) == 'string') {
+            $input[$field]['error'] = (int) $input[$field]['error'];
+        }
+        
         if (!is_array($input[$field])) {
             return false;
         }


### PR DESCRIPTION
The change is needed because the validation of the if-s are based on integer values and not string.  As $input['field']['error'] is passed as string, all the if are failing.